### PR TITLE
adapt go mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/prometheus/procfs
+module github.com/chensunny/procfs
 
 require golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/chensunny/procfs
+module github.com/ncabatoff/procfs
 
 require golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4


### PR DESCRIPTION

change module name to adapt go mod which go build panic

```
go: github.com/ncabatoff/procfs@v0.0.0-20190403104016-ea9eea638872: parsing go.mod: unexpected module path "github.com/prometheus/procfs"
```